### PR TITLE
Remove unused import in BulletPointHtmlConverter

### DIFF
--- a/src/org_to_anki/converters/BulletPointHtmlConverter.py
+++ b/src/org_to_anki/converters/BulletPointHtmlConverter.py
@@ -8,7 +8,6 @@ from bs4 import BeautifulSoup
 
 import re
 import codecs
-import chardet
 
 
 ## TODO => review these


### PR DESCRIPTION
that unused import causes anki-remote-decks to crash in anki version 2.1.54